### PR TITLE
Provide a useful error message to the customer when a charge fails.

### DIFF
--- a/app/code/community/Inchoo/Stripe/Model/Payment.php
+++ b/app/code/community/Inchoo/Stripe/Model/Payment.php
@@ -53,7 +53,7 @@ class Inchoo_Stripe_Model_Payment extends Mage_Payment_Model_Method_Cc
 			));
 		} catch (Exception $e) {
 			$this->debugData($e->getMessage());
-			Mage::throwException(Mage::helper('paygate')->__('Payment capturing error.'));
+			Mage::throwException(Mage::helper('paygate')->__("There was a problem charging your credit card. " . $e->getMessage()));
 		}
 		
 		//Mage::log($charge,null,'stripe.log',true);


### PR DESCRIPTION
When a charge fails, the customer should be given some useful information about why it failed.  This change will including the stripe error in the alert message shown to the customer so they know if it was declined, or if there was a CVC error, etc.
